### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that provides call graph analysis capabilities to LLMs through the [nuanced](https://github.com/nuanced-dev/nuanced) library.
 
+<a href="https://glama.ai/mcp/servers/ugp1lwtv22">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ugp1lwtv22/badge" alt="Nuanced Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server enables LLMs to understand code structure by accessing function call graphs through standardized tools and resources. It allows AI assistants to:


### PR DESCRIPTION
This PR adds a badge for the [Nuanced MCP Server](https://glama.ai/mcp/servers/ugp1lwtv22) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ugp1lwtv22">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ugp1lwtv22/badge" alt="Nuanced Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.